### PR TITLE
Delay auth response

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,5 +8,7 @@ AWS_S3_BUCKET=instead-development
 UPLOAD_TIME=300
 DATABASE_URL=postgres://localhost:5432/postgres
 REDIS_URL=redis://localhost:6379
+MIN_AUTH_TIME=400
+MAX_AUTH_TIME=500
 SECURE_KEY=secure
 GARBAGE_SEED=garbage

--- a/backend/src/config/config.spec.ts
+++ b/backend/src/config/config.spec.ts
@@ -1,0 +1,44 @@
+import * as config from './config'
+
+describe('config', () => {
+    describe('string', () => {
+        test('returns value if it exists', () => {
+            process.env.TEST1 = 'VALUE'
+            const value = config.string('TEST1')
+            expect(value).toEqual('VALUE')
+        })
+
+        test('throws if doesn\'t exist', () => {
+            expect(() => config.string('TEST2')).toThrow()
+        })
+    })
+
+    describe('int', () => {
+        test('converts to integer', () => {
+            process.env.TESTINT = '100'
+            const value = config.int('TESTINT')
+            expect(value).toEqual(100)
+        })
+    })
+
+    describe('strings', () => {
+        test('splits on comma', () => {
+            process.env.TESTSTRINGS = 'a,b'
+            const value = config.strings('TESTSTRINGS')
+            expect(value).toHaveLength(2)
+            expect(value[0]).toEqual('a')
+            expect(value[1]).toEqual('b')
+        })
+    })
+
+    describe('isLocalDev', () => {
+        test('returns true during testing', () => {
+            expect(config.isLocalDev()).toEqual(true)
+        })
+
+        test('returns false if NODE_ENV == production', () => {
+            process.env.NODE_ENV = 'production'
+            expect(config.isLocalDev()).toEqual(false)
+        })
+    })
+})

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -5,28 +5,21 @@ function split(input: string) {
         return input.split(',')
 }
 
-function requireVar(name: string) {
+export function requireString(name: string) {
     const value = process.env[name]
     if (value === undefined)
         throw new Error(`Environment variable ${name} required, but not found`)
     return value
 }
 
-export default {
-    localDev: process.env.NODE_ENV != 'production',
-    clientOrigin: split(requireVar('CLIENT_ORIGIN')),
-    webPort: requireVar('PORT'),
-    aws: {
-        accessKeyId: requireVar('AWS_ACCESS_KEY_ID'),
-        secretKey: requireVar('AWS_SECRET_KEY'),
-        region: requireVar('AWS_REGION'),
-        s3Bucket: requireVar('AWS_S3_BUCKET'),
-    },
-    uploadTime: parseInt(requireVar('UPLOAD_TIME')),
-    minimumAuthTime: parseInt(requireVar('MIN_AUTH_TIME')),
-    maxAuthTime: parseInt(requireVar('MAX_AUTH_TIME')),
-    databaseUrl: requireVar('DATABASE_URL'),
-    redisUrl: requireVar('REDIS_URL'),
-    sessionSecret: split(requireVar('SECURE_KEY')),
-    garbageSeed: requireVar('GARBAGE_SEED'),
+export function requireInt(name: string) {
+    return parseInt(requireString(name))
+}
+
+export function requireStrings(name: string) {
+    return split(requireString(name))
+}
+
+export function isLocalDev() {
+    return process.env.NODE_ENV != 'production'
 }

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -16,6 +16,8 @@ export default {
         s3Bucket: process.env.AWS_S3_BUCKET,
     },
     uploadTime: parseInt(process.env.UPLOAD_TIME),
+    minimumAuthTime: parseInt(process.env.MIN_AUTH_TIME),
+    maxAuthTime: parseInt(process.env.MAX_AUTH_TIME),
     databaseUrl: process.env.DATABASE_URL,
     redisUrl: process.env.REDIS_URL,
     sessionSecret: split(process.env.SECURE_KEY),

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -5,19 +5,19 @@ function split(input: string) {
         return input.split(',')
 }
 
-export function requireString(name: string) {
+export function string(name: string) {
     const value = process.env[name]
     if (value === undefined)
         throw new Error(`Environment variable ${name} required, but not found`)
     return value
 }
 
-export function requireInt(name: string) {
-    return parseInt(requireString(name))
+export function int(name: string) {
+    return parseInt(string(name))
 }
 
-export function requireStrings(name: string) {
-    return split(requireString(name))
+export function strings(name: string) {
+    return split(string(name))
 }
 
 export function isLocalDev() {

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -5,21 +5,28 @@ function split(input: string) {
         return input.split(',')
 }
 
+function requireVar(name: string) {
+    const value = process.env[name]
+    if (value === undefined)
+        throw new Error(`Environment variable ${name} required, but not found`)
+    return value
+}
+
 export default {
     localDev: process.env.NODE_ENV != 'production',
-    clientOrigin: split(process.env.CLIENT_ORIGIN),
-    webPort: process.env.PORT,
+    clientOrigin: split(requireVar('CLIENT_ORIGIN')),
+    webPort: requireVar('PORT'),
     aws: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretKey: process.env.AWS_SECRET_KEY,
-        region: process.env.AWS_REGION,
-        s3Bucket: process.env.AWS_S3_BUCKET,
+        accessKeyId: requireVar('AWS_ACCESS_KEY_ID'),
+        secretKey: requireVar('AWS_SECRET_KEY'),
+        region: requireVar('AWS_REGION'),
+        s3Bucket: requireVar('AWS_S3_BUCKET'),
     },
-    uploadTime: parseInt(process.env.UPLOAD_TIME),
-    minimumAuthTime: parseInt(process.env.MIN_AUTH_TIME),
-    maxAuthTime: parseInt(process.env.MAX_AUTH_TIME),
-    databaseUrl: process.env.DATABASE_URL,
-    redisUrl: process.env.REDIS_URL,
-    sessionSecret: split(process.env.SECURE_KEY),
-    garbageSeed: process.env.GARBAGE_SEED,
+    uploadTime: parseInt(requireVar('UPLOAD_TIME')),
+    minimumAuthTime: parseInt(requireVar('MIN_AUTH_TIME')),
+    maxAuthTime: parseInt(requireVar('MAX_AUTH_TIME')),
+    databaseUrl: requireVar('DATABASE_URL'),
+    redisUrl: requireVar('REDIS_URL'),
+    sessionSecret: split(requireVar('SECURE_KEY')),
+    garbageSeed: requireVar('GARBAGE_SEED'),
 }

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,9 +1,9 @@
 import cors, { CorsOptions } from 'cors'
-import config from '../config/config'
+import { requireStrings} from '../config/config'
 
 const settings: CorsOptions = {
     origin: function (origin, callback) {
-        if (config.clientOrigin.some(x => x === origin) || !origin) {
+        if (requireStrings('CLIENT_ORIGIN').some(x => x === origin) || !origin) {
             callback(null, true)
         } else {
             callback(new Error(`Origin ${origin} not allowed by CORS`))

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,9 +1,9 @@
 import cors, { CorsOptions } from 'cors'
-import { requireStrings} from '../config/config'
+import * as config from '../config/config'
 
 const settings: CorsOptions = {
     origin: function (origin, callback) {
-        if (requireStrings('CLIENT_ORIGIN').some(x => x === origin) || !origin) {
+        if (config.strings('CLIENT_ORIGIN').some(x => x === origin) || !origin) {
             callback(null, true)
         } else {
             callback(new Error(`Origin ${origin} not allowed by CORS`))

--- a/backend/src/middleware/delay-response.spec.ts
+++ b/backend/src/middleware/delay-response.spec.ts
@@ -1,0 +1,36 @@
+import delayResponse from './delay-response'
+import config from '../config/config'
+import { Request, Response, NextFunction } from 'express'
+
+jest.mock('../config/config')
+
+describe('delay-response', () => {
+    test('records start time and delays call to next()', () => {
+        jest.useFakeTimers()
+        const send = jest.fn()
+        const next = jest.fn()
+        const req = { send } as any
+        config.minimumAuthTime = 6
+        config.maxAuthTime = 10
+        const startTime = Date.now()
+        delayResponse({} as any, req, next as any)
+        expect(next).toBeCalled()
+        req.send()
+        expect(send).toBeCalledTimes(0)
+        jest.runAllTimers()
+        expect(Date.now() - startTime).toBeGreaterThan(5)
+        expect(send).toBeCalled()
+    })
+
+    test('doesn\'t delay if delay is as short as operation', () => {
+        const send = jest.fn()
+        const next = jest.fn()
+        const req = { send } as any
+        config.minimumAuthTime = config.maxAuthTime = 0
+        const startTime = Date.now()
+        delayResponse({} as any, req, next as any)
+        expect(next).toBeCalled()
+        req.send()
+        expect(send).toBeCalled()
+    })
+})

--- a/backend/src/middleware/delay-response.spec.ts
+++ b/backend/src/middleware/delay-response.spec.ts
@@ -1,7 +1,4 @@
 import delayResponse from './delay-response'
-import config from '../config/config'
-
-jest.mock('../config/config')
 
 describe('delay-response', () => {
     test('records start time and delays call to next()', () => {
@@ -9,10 +6,8 @@ describe('delay-response', () => {
         const send = jest.fn()
         const next = jest.fn()
         const req = { send } as any
-        config.minimumAuthTime = 6
-        config.maxAuthTime = 10
         const startTime = Date.now()
-        delayResponse({} as any, req, next as any)
+        delayResponse(6, 10)({} as any, req, next as any)
         expect(next).toBeCalled()
         req.send()
         expect(send).toBeCalledTimes(0)
@@ -25,9 +20,8 @@ describe('delay-response', () => {
         const send = jest.fn()
         const next = jest.fn()
         const req = { send } as any
-        config.minimumAuthTime = config.maxAuthTime = 0
         const startTime = Date.now()
-        delayResponse({} as any, req, next as any)
+        delayResponse(0, 0)({} as any, req, next as any)
         expect(next).toBeCalled()
         req.send()
         expect(send).toBeCalled()

--- a/backend/src/middleware/delay-response.spec.ts
+++ b/backend/src/middleware/delay-response.spec.ts
@@ -1,6 +1,5 @@
 import delayResponse from './delay-response'
 import config from '../config/config'
-import { Request, Response, NextFunction } from 'express'
 
 jest.mock('../config/config')
 

--- a/backend/src/middleware/delay-response.spec.ts
+++ b/backend/src/middleware/delay-response.spec.ts
@@ -7,12 +7,13 @@ describe('delay-response', () => {
         const next = jest.fn()
         const req = { send } as any
         const startTime = Date.now()
-        delayResponse(6, 10)({} as any, req, next as any)
+        delayResponse(500, 500)({} as any, req, next as any)
         expect(next).toBeCalled()
         req.send()
         expect(send).toBeCalledTimes(0)
-        jest.runAllTimers()
-        expect(Date.now() - startTime).toBeGreaterThan(5)
+        jest.advanceTimersByTime(450)
+        expect(send).toBeCalledTimes(0)
+        jest.advanceTimersByTime(100)
         expect(send).toBeCalled()
     })
 
@@ -20,7 +21,6 @@ describe('delay-response', () => {
         const send = jest.fn()
         const next = jest.fn()
         const req = { send } as any
-        const startTime = Date.now()
         delayResponse(0, 0)({} as any, req, next as any)
         expect(next).toBeCalled()
         req.send()

--- a/backend/src/middleware/delay-response.ts
+++ b/backend/src/middleware/delay-response.ts
@@ -1,7 +1,7 @@
 import { Response, Request, NextFunction } from 'express'
 import config from '../config/config'
 
-export function delayResponse(req: Request, res: Response, next: NextFunction) {
+export default function delayResponse(req: Request, res: Response, next: NextFunction) {
     req.startTime = Date.now()
 
     const send = res.send

--- a/backend/src/middleware/delay-response.ts
+++ b/backend/src/middleware/delay-response.ts
@@ -8,10 +8,10 @@ export default function delayResponse(min: number, max: number) {
 
         const send = res.send
         res.send = body => {
-            const minTime = Math.floor(Math.random()*range) + min
-            const scheduledFinish = req.startTime + minTime
+            const delay = Math.floor(Math.random()*range) + min
+            const scheduledFinish = req.startTime + delay
             const now = Date.now()
-            console.log(`delay-response delayed: ${minTime} actual: ${now - req.startTime}`)
+            console.log(`delay-response delayed: ${delay} actual: ${now - req.startTime}`)
             if (scheduledFinish > now)
                 setTimeout(() => send.call(res, body), scheduledFinish - now)
             else

--- a/backend/src/middleware/delay-response.ts
+++ b/backend/src/middleware/delay-response.ts
@@ -1,19 +1,22 @@
 import { Response, Request, NextFunction } from 'express'
-import config from '../config/config'
 
-export default function delayResponse(req: Request, res: Response, next: NextFunction) {
-    req.startTime = Date.now()
+export default function delayResponse(min: number, max: number) {
 
-    const send = res.send
-    res.send = body => {
-        const minTime = Math.floor(Math.random()*(config.maxAuthTime - config.minimumAuthTime)) + config.minimumAuthTime
-        const scheduledFinish = req.startTime + minTime
-        const now = Date.now()
-        console.log(`delay-response delayed: ${minTime} actual: ${now - req.startTime}`)
-        if (scheduledFinish > now)
-            setTimeout(() => send.call(res, body), scheduledFinish - now)
-        else
-            return send.call(res, body)
+    const range = max - min
+    return (req: Request, res: Response, next: NextFunction) => {
+        req.startTime = Date.now()
+
+        const send = res.send
+        res.send = body => {
+            const minTime = Math.floor(Math.random()*range) + min
+            const scheduledFinish = req.startTime + minTime
+            const now = Date.now()
+            console.log(`delay-response delayed: ${minTime} actual: ${now - req.startTime}`)
+            if (scheduledFinish > now)
+                setTimeout(() => send.call(res, body), scheduledFinish - now)
+            else
+                return send.call(res, body)
+        }
+        next()
     }
-    next()
 }

--- a/backend/src/middleware/delay-response.ts
+++ b/backend/src/middleware/delay-response.ts
@@ -1,0 +1,19 @@
+import { Response, Request, NextFunction } from 'express'
+import config from '../config/config'
+
+export function delayResponse(req: Request, res: Response, next: NextFunction) {
+    req.startTime = Date.now()
+
+    const send = res.send
+    res.send = body => {
+        const minTime = Math.floor(Math.random()*(config.maxAuthTime - config.minimumAuthTime)) + config.minimumAuthTime
+        const scheduledFinish = req.startTime + minTime
+        const now = Date.now()
+        console.log(`delay-response delayed: ${minTime} actual: ${now - req.startTime}`)
+        if (scheduledFinish > now)
+            setTimeout(() => send.call(res, body), scheduledFinish - now)
+        else
+            return send.call(res, body)
+    }
+    next()
+}

--- a/backend/src/middleware/force-https.ts
+++ b/backend/src/middleware/force-https.ts
@@ -1,9 +1,9 @@
-import config from '../config/config'
+import { isLocalDev } from '../config/config'
 import { Request, Response, NextFunction } from 'express-serve-static-core'
 
 export default function requireHTTPS(req: Request, res: Response, next: NextFunction) {
     // The 'x-forwarded-proto' check is for Heroku
-    if (!config.localDev && !req.secure && req.get('x-forwarded-proto') !== 'https') {
+    if (!isLocalDev() && !req.secure && req.get('x-forwarded-proto') !== 'https') {
         if (req.method === 'GET') {
             return res.redirect('https://' + req.get('host') + req.url)
         } else {

--- a/backend/src/middleware/force-https.ts
+++ b/backend/src/middleware/force-https.ts
@@ -1,9 +1,9 @@
-import { isLocalDev } from '../config/config'
+import * as config from '../config/config'
 import { Request, Response, NextFunction } from 'express-serve-static-core'
 
 export default function requireHTTPS(req: Request, res: Response, next: NextFunction) {
     // The 'x-forwarded-proto' check is for Heroku
-    if (!isLocalDev() && !req.secure && req.get('x-forwarded-proto') !== 'https') {
+    if (!config.isLocalDev() && !req.secure && req.get('x-forwarded-proto') !== 'https') {
         if (req.method === 'GET') {
             return res.redirect('https://' + req.get('host') + req.url)
         } else {

--- a/backend/src/middleware/session.ts
+++ b/backend/src/middleware/session.ts
@@ -1,14 +1,14 @@
 import session, { SessionOptions } from 'express-session'
 import redis from 'redis'
-import { isLocalDev, requireStrings, requireString } from '../config/config'
+import * as config from '../config/config'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const RedisStore = require('connect-redis')(session)
 const client = redis.createClient({
-    url: requireString('REDIS_URL'),
+    url: config.string('REDIS_URL'),
 })
 
 const sessionConfig: SessionOptions = {
-    secret: requireStrings('SECURE_KEY'),
+    secret: config.strings('SECURE_KEY'),
     name: 'instead-photos',
     store: new RedisStore({ client }),
     resave: false,
@@ -21,7 +21,7 @@ const sessionConfig: SessionOptions = {
     },
 }
 
-if (!isLocalDev()) {
+if (!config.isLocalDev()) {
     sessionConfig.cookie.secure = true
 }
 

--- a/backend/src/middleware/session.ts
+++ b/backend/src/middleware/session.ts
@@ -1,14 +1,14 @@
 import session, { SessionOptions } from 'express-session'
 import redis from 'redis'
-import config from '../config/config'
+import { isLocalDev, requireStrings, requireString } from '../config/config'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const RedisStore = require('connect-redis')(session)
 const client = redis.createClient({
-    url: config.redisUrl,
+    url: requireString('REDIS_URL'),
 })
 
 const sessionConfig: SessionOptions = {
-    secret: config.sessionSecret,
+    secret: requireStrings('SECURE_KEY'),
     name: 'instead-photos',
     store: new RedisStore({ client }),
     resave: false,
@@ -21,7 +21,7 @@ const sessionConfig: SessionOptions = {
     },
 }
 
-if (!config.localDev) {
+if (!isLocalDev()) {
     sessionConfig.cookie.secure = true
 }
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,10 +2,13 @@ import Router from 'express-promise-router'
 import Container from 'typedi'
 import AuthService from '../services/AuthService'
 import validate from '../middleware/validate'
+import { delayResponse } from '../middleware/delay-response'
 import { NewUser } from 'auth'
 
 const router = Router()
 const authService = Container.get(AuthService)
+
+router.use(delayResponse)
 
 router.post('/startLogin', async function (req, res) {
     const responseData = await authService.startLogin(req.session, req.body.username, req.body.clientEphemeralPublic)

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -4,11 +4,12 @@ import AuthService from '../services/AuthService'
 import validate from '../middleware/validate'
 import delayResponse from '../middleware/delay-response'
 import { NewUser } from 'auth'
+import { requireInt } from '../config/config'
 
 const router = Router()
 const authService = Container.get(AuthService)
 
-router.use(delayResponse)
+router.use(delayResponse(requireInt('MIN_AUTH_TIME'), requireInt('MAX_AUTH_TIME')))
 
 router.post('/startLogin', async function (req, res) {
     const responseData = await authService.startLogin(req.session, req.body.username, req.body.clientEphemeralPublic)

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -4,12 +4,12 @@ import AuthService from '../services/AuthService'
 import validate from '../middleware/validate'
 import delayResponse from '../middleware/delay-response'
 import { NewUser } from 'auth'
-import { requireInt } from '../config/config'
+import * as config from '../config/config'
 
 const router = Router()
 const authService = Container.get(AuthService)
 
-router.use(delayResponse(requireInt('MIN_AUTH_TIME'), requireInt('MAX_AUTH_TIME')))
+router.use(delayResponse(config.int('MIN_AUTH_TIME'), config.int('MAX_AUTH_TIME')))
 
 router.post('/startLogin', async function (req, res) {
     const responseData = await authService.startLogin(req.session, req.body.username, req.body.clientEphemeralPublic)

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,7 +2,7 @@ import Router from 'express-promise-router'
 import Container from 'typedi'
 import AuthService from '../services/AuthService'
 import validate from '../middleware/validate'
-import { delayResponse } from '../middleware/delay-response'
+import delayResponse from '../middleware/delay-response'
 import { NewUser } from 'auth'
 
 const router = Router()

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,7 +5,7 @@ import bodyParser from 'body-parser'
 import morgan from 'morgan'
 import helmet from 'helmet'
 import authManager from './middleware/auth-strategies'
-import config from './config/config'
+import { isLocalDev, requireInt } from './config/config'
 import forceHttps from './middleware/force-https'
 import session from './middleware/session'
 import auth from './routes/auth'
@@ -18,7 +18,7 @@ const app = express()
 app.use(forceHttps)
 app.use(helmet())
 app.use(cors)
-if (!config.localDev)
+if (!isLocalDev())
     app.set('trust proxy', 1) // trust first proxy
 app.use(session)
 
@@ -29,10 +29,11 @@ app.use(morgan('dev'))
 app.use('/auth', auth)
 app.use('/api', authManager.authenticateSession, api, forwardErrors)
 
-if (!config.localDev) {
+if (!isLocalDev()) {
     const relativePathToReact = '/../../../client/build'
     const reactPath = path.join(__dirname, relativePathToReact)
     httpServer(app, reactPath)
 }
 
-app.listen(config.webPort, () => console.log(`Server listening on ${config.webPort}`))
+const port = requireInt('PORT')
+app.listen(port, () => console.log(`Server listening on ${port}`))

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,7 +5,7 @@ import bodyParser from 'body-parser'
 import morgan from 'morgan'
 import helmet from 'helmet'
 import authManager from './middleware/auth-strategies'
-import { isLocalDev, requireInt } from './config/config'
+import * as config from './config/config'
 import forceHttps from './middleware/force-https'
 import session from './middleware/session'
 import auth from './routes/auth'
@@ -18,7 +18,7 @@ const app = express()
 app.use(forceHttps)
 app.use(helmet())
 app.use(cors)
-if (!isLocalDev())
+if (!config.isLocalDev())
     app.set('trust proxy', 1) // trust first proxy
 app.use(session)
 
@@ -29,11 +29,11 @@ app.use(morgan('dev'))
 app.use('/auth', auth)
 app.use('/api', authManager.authenticateSession, api, forwardErrors)
 
-if (!isLocalDev()) {
+if (!config.isLocalDev()) {
     const relativePathToReact = '/../../../client/build'
     const reactPath = path.join(__dirname, relativePathToReact)
     httpServer(app, reactPath)
 }
 
-const port = requireInt('PORT')
+const port = config.int('PORT')
 app.listen(port, () => console.log(`Server listening on ${port}`))

--- a/backend/src/services/AWSService.ts
+++ b/backend/src/services/AWSService.ts
@@ -1,5 +1,5 @@
 import { Service } from 'typedi'
-import { requireString, requireInt } from '../config/config'
+import * as config from '../config/config'
 import aws from 'aws-sdk'
 
 @Service()
@@ -8,10 +8,10 @@ export default class AWSService {
     private s3: aws.S3
 
     constructor() {
-        const accessKeyId = requireString('AWS_ACCESS_KEY_ID')
-        const secretKey = requireString('AWS_SECRET_KEY')
-        const region = requireString('AWS_REGION')
-        this.bucket = requireString('AWS_S3_BUCKET')
+        const accessKeyId = config.string('AWS_ACCESS_KEY_ID')
+        const secretKey = config.string('AWS_SECRET_KEY')
+        const region = config.string('AWS_REGION')
+        this.bucket = config.string('AWS_S3_BUCKET')
 
         aws.config.update({
             region: region,
@@ -31,7 +31,7 @@ export default class AWSService {
         const s3Params = {
             Bucket: this.bucket,
             Key: fileName,
-            Expires: requireInt('UPLOAD_TIME'),
+            Expires: config.int('UPLOAD_TIME'),
             ContentType: fileType,
             ContentMD5: md5,
             ACL: 'public-read',

--- a/backend/src/services/AWSService.ts
+++ b/backend/src/services/AWSService.ts
@@ -1,5 +1,5 @@
 import { Service } from 'typedi'
-import config from '../config/config'
+import { requireString, requireInt } from '../config/config'
 import aws from 'aws-sdk'
 
 @Service()
@@ -8,11 +8,10 @@ export default class AWSService {
     private s3: aws.S3
 
     constructor() {
-        const awsConfig = config.aws
-        const accessKeyId = awsConfig.accessKeyId
-        const secretKey = awsConfig.secretKey
-        const region = awsConfig.region
-        this.bucket = awsConfig.s3Bucket
+        const accessKeyId = requireString('AWS_ACCESS_KEY_ID')
+        const secretKey = requireString('AWS_SECRET_KEY')
+        const region = requireString('AWS_REGION')
+        this.bucket = requireString('AWS_S3_BUCKET')
 
         aws.config.update({
             region: region,
@@ -32,7 +31,7 @@ export default class AWSService {
         const s3Params = {
             Bucket: this.bucket,
             Key: fileName,
-            Expires: config.uploadTime,
+            Expires: requireInt('UPLOAD_TIME'),
             ContentType: fileType,
             ContentMD5: md5,
             ACL: 'public-read',

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -2,7 +2,7 @@ import { Service, Inject } from 'typedi'
 import srp from 'secure-remote-password/server'
 import crypto from '../util/crypto-promise'
 import { generateCombination } from '../util/animalGenerator'
-import config from '../config/config'
+import { requireString } from '../config/config'
 import UserService from './UserService'
 import { StartLoginResult, FinishLoginResult, StartSignupResult, FinishSignupResult, NewUser } from 'auth'
 
@@ -30,7 +30,7 @@ export default class AuthService {
             }
         } else {
             const bytes = await crypto.randomBytes(256)
-            const hash = crypto.createHash('sha256').update(username).update(config.garbageSeed)
+            const hash = crypto.createHash('sha256').update(username).update(requireString('GARBAGE_SEED'))
             session.loginInfo = {
                 loginFake: true,
             }

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -2,7 +2,7 @@ import { Service, Inject } from 'typedi'
 import srp from 'secure-remote-password/server'
 import crypto from '../util/crypto-promise'
 import { generateCombination } from '../util/animalGenerator'
-import { requireString } from '../config/config'
+import * as config from '../config/config'
 import UserService from './UserService'
 import { StartLoginResult, FinishLoginResult, StartSignupResult, FinishSignupResult, NewUser } from 'auth'
 
@@ -30,7 +30,7 @@ export default class AuthService {
             }
         } else {
             const bytes = await crypto.randomBytes(256)
-            const hash = crypto.createHash('sha256').update(username).update(requireString('GARBAGE_SEED'))
+            const hash = crypto.createHash('sha256').update(username).update(config.string('GARBAGE_SEED'))
             session.loginInfo = {
                 loginFake: true,
             }

--- a/backend/src/services/DatabaseService.spec.ts
+++ b/backend/src/services/DatabaseService.spec.ts
@@ -1,6 +1,5 @@
 import { mocked } from 'ts-jest/utils'
 import DatabaseService from './DatabaseService'
-import pg, { PoolClient } from 'pg'
 
 jest.mock('pg')
 jest.mock('pg-camelcase')

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -1,5 +1,5 @@
 import pg, { Pool, ClientBase } from 'pg'
-import config from '../config/config'
+import { requireString } from '../config/config'
 import { Service } from 'typedi'
 import { inject } from 'pg-camelcase'
 
@@ -12,7 +12,7 @@ export default class DatabaseService {
 
     constructor() {
         inject(pg)
-        this.pool = (config.databaseUrl === undefined) ? new Pool() : new Pool({connectionString: config.databaseUrl})
+        this.pool = new Pool({connectionString: requireString('DATABASE_URL')})
     }
 
     async transaction(commands: TransactionContents) {

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -1,5 +1,5 @@
 import pg, { Pool, ClientBase } from 'pg'
-import { requireString } from '../config/config'
+import * as config from '../config/config'
 import { Service } from 'typedi'
 import { inject } from 'pg-camelcase'
 
@@ -12,7 +12,7 @@ export default class DatabaseService {
 
     constructor() {
         inject(pg)
-        this.pool = new Pool({connectionString: requireString('DATABASE_URL')})
+        this.pool = new Pool({connectionString: config.string('DATABASE_URL')})
     }
 
     async transaction(commands: TransactionContents) {

--- a/backend/src/services/PostService.ts
+++ b/backend/src/services/PostService.ts
@@ -4,7 +4,7 @@ import AWSService from './AWSService'
 import * as Posts from '../queries/posts.gen'
 import uuidv1 from 'uuid/v1'
 import { SimpleEventDispatcher } from 'strongly-typed-events'
-import { requireInt } from '../config/config'
+import * as config from '../config/config'
 import { DeletePostResult, StartPostResult } from 'api'
 
 @Service()
@@ -64,6 +64,6 @@ export default class PostService {
     }
 
     onPostCreated(postId: number) {
-        setTimeout(() => Container.get(PostService).removePostIfNotPublished(postId), (requireInt('UPLOAD_TIME') + 1)*1000)
+        setTimeout(() => Container.get(PostService).removePostIfNotPublished(postId), (config.int('UPLOAD_TIME') + 1)*1000)
     }
 }

--- a/backend/src/services/PostService.ts
+++ b/backend/src/services/PostService.ts
@@ -4,7 +4,7 @@ import AWSService from './AWSService'
 import * as Posts from '../queries/posts.gen'
 import uuidv1 from 'uuid/v1'
 import { SimpleEventDispatcher } from 'strongly-typed-events'
-import config from '../config/config'
+import { requireInt } from '../config/config'
 import { DeletePostResult, StartPostResult } from 'api'
 
 @Service()
@@ -64,6 +64,6 @@ export default class PostService {
     }
 
     onPostCreated(postId: number) {
-        setTimeout(() => Container.get(PostService).removePostIfNotPublished(postId), (config.uploadTime + 1)*1000)
+        setTimeout(() => Container.get(PostService).removePostIfNotPublished(postId), (requireInt('UPLOAD_TIME') + 1)*1000)
     }
 }

--- a/backend/src/types/interfaces.d.ts
+++ b/backend/src/types/interfaces.d.ts
@@ -22,6 +22,7 @@ export interface SignupInfo {
 declare module 'express-serve-static-core' {
     interface Request {
         user?: User,
+        startTime?: number,
     }
 }
 


### PR DESCRIPTION
Delay responses from auth API so they all take roughly the same amount of time.

Decentralised responsibility for config variables, and made them throw if not present.